### PR TITLE
Update Dockerfile to use a non-removed JDK and a new grobid base 

### DIFF
--- a/Dockerfile.software
+++ b/Dockerfile.software
@@ -2,7 +2,7 @@
 # build builder image
 # -------------------
 
-FROM openjdk:17-jdk-slim as builder
+FROM eclipse-temurin:17.0.15_6-jdk AS builder
 
 USER root
 
@@ -52,7 +52,7 @@ RUN wget https://github.com/kermitt2/Pub2TEI/archive/refs/heads/master.zip && \
 # build runtime image
 # -------------------
 
-FROM lfoppiano/grobid:0.8.2-full as runtime
+FROM lfoppiano/grobid:0.8.2.1-full AS runtime
 
 # setting locale is likely useless but to be sure
 ENV LANG C.UTF-8
@@ -83,7 +83,7 @@ VOLUME ["/opt/grobid/grobid-home/tmp"]
 
 ARG GROBID_VERSION
 ENV GROBID_VERSION=${GROBID_VERSION:-latest}
-ENV SOFTWARE_MENTIONS_OPTS "-Djava.library.path=/opt/grobid/grobid-home/lib/lin-64:/usr/local/lib/python3.8/dist-packages/jep --add-opens java.base/java.lang=ALL-UNNAMED"
+ENV SOFTWARE_MENTIONS_OPTS="-Djava.library.path=/opt/grobid/grobid-home/lib/lin-64:/usr/local/lib/python3.8/dist-packages/jep --add-opens java.base/java.lang=ALL-UNNAMED"
 
 CMD ["./software-mentions/bin/software-mentions", "server", "software-mentions/resources/config/config.yml"]
 

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -256,7 +256,7 @@
 
         <!-- Footer -->
         <footer>
-            <p><span style="color: #848484;">&copy; The contributors - 2025</span></p>
+            <p><span style="color: #848484;">&copy; The contributors - 2026</span></p>
         </footer>
     </div>
 


### PR DESCRIPTION
It seems that openjdk-17-jdk-slim has disappeared from the docker hub causing a discrete annoyance in the grobid builds. This PR should remediate that. See https://github.com/kermitt2/grobid/issues/1349 